### PR TITLE
Changed pronoun to Edwardian-stylebook-compliant term for humans

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Chug is a simple [Grunt](http://gruntjs.com/)-based development tool that will
 build a nice static HTML site for you, based on your many templates and assets.
 Chug is a little bit opinionated, and assumes that you are an intelligent and
-attractive person that loves Mustache and Sass.
+attractive person who loves Mustache and Sass.
 
 ## Getting Started
 Put Chug's gruntfile in a directory and run `grunt new` to get your directory


### PR DESCRIPTION
Some stylebooks require using "who" for clauses referring to human beings. The distinction from "that" is probably losing favor, but if you want to add some _Downton Abbey_ primness to the README, here's a simple way to obtain it.
